### PR TITLE
Blacklistfilter update: aggregators, new blacklists, downloader fix

### DIFF
--- a/blacklistfilter/blacklist_downloader/bl_downloader.py.in
+++ b/blacklistfilter/blacklist_downloader/bl_downloader.py.in
@@ -88,11 +88,11 @@ class Blacklist:
             if req.status_code == 200:
                 data = req.content
 
-                new_entities = self.extract_entities(data)
+                new_entities = sorted(self.extract_entities(data), key=type(self).comparator)
 
                 if new_entities != self.entities:
                     # Blacklist entities changed since last download
-                    self.entities = sorted(new_entities, key=type(self).comparator)
+                    self.entities = new_entities
                     if repo_path:
                         self.write_to_repo()
                     self.last_download = time.time()

--- a/blacklistfilter/blacklist_downloader/bl_downloader_config.xml
+++ b/blacklistfilter/blacklist_downloader/bl_downloader_config.xml
@@ -66,6 +66,33 @@
                 <element name="name">TOR exit nodes</element>
                 <element name="download_interval">10</element>
             </struct> -->
+
+            <struct>
+                <element name="id">6</element>
+                <element name="type">Mining</element>
+                <element name="method">web</element>
+                <element name="source">https://raw.githubusercontent.com/andoniaf/mining-pools-list/master/mining-pools_IP.lst</element>
+                <element name="name">Andoniaf Miners</element>
+                <element name="download_interval">10</element>
+            </struct>
+
+            <struct>
+                <element name="id">7</element>
+                <element name="type">Mining</element>
+                <element name="method">web</element>
+                <element name="source">https://isc.sans.edu/api/threatlist/miner?text</element>
+                <element name="name">SANS Miners</element>
+                <element name="download_interval">10</element>
+            </struct>
+
+            <struct>
+                <element name="id">8</element>
+                <element name="type">Mining</element>
+                <element name="method">web</element>
+                <element name="source">https://cryptoioc.ch/downloads/csv</element>
+                <element name="name">Cryptoioc Miners</element>
+                <element name="download_interval">10</element>
+            </struct>
         </array>
 
         <array type="URL">

--- a/blacklistfilter/ipblacklist_aggregator.py
+++ b/blacklistfilter/ipblacklist_aggregator.py
@@ -87,11 +87,18 @@ def sendEvents():
     for key in eventList:
         event = eventList[key]
         try:
-            if len(event['targets']) > MAX_DST_IPS_PER_EVENT:
-                event['targets'] = event['targets'][:MAX_DST_IPS_PER_EVENT]
+            # To avoid too long messages, split the event if there are more 1000 IPs
+            if len(event["targets"]) > MAX_DST_IPS_PER_EVENT:
+                targets = event["targets"]
+                while targets:
+                    event_copy = event.copy()
+                    event_copy["targets"] = targets[:MAX_DST_IPS_PER_EVENT]
+                    targets = targets[MAX_DST_IPS_PER_EVENT:]
+                    trap.send(bytearray(json.dumps(event_copy), "utf-8"))
 
-            # Send data to output interface
-            trap.send(bytearray(json.dumps(event), "utf-8"))
+            else:
+                # Send data to output interface
+                trap.send(bytearray(json.dumps(event), "utf-8"))
         except pytrap.Terminated:
             print("Terminated TRAP.")
             break

--- a/blacklistfilter/ipblacklist_aggregator.py
+++ b/blacklistfilter/ipblacklist_aggregator.py
@@ -23,6 +23,10 @@ lock = Lock()
 # therefore, let's put lower ports into IDEA messages.
 MINSRCPORT=30000
 
+# Maximum number of dest. IPs in an event record (if there are more, they are trimmed)
+MAX_DST_IPS_PER_EVENT = 1000
+
+
 class RepeatedTimer(object):
     def __init__(self, interval, function):
         self._timer     = None
@@ -83,6 +87,9 @@ def sendEvents():
     for key in eventList:
         event = eventList[key]
         try:
+            if len(event['targets']) > MAX_DST_IPS_PER_EVENT:
+                event['targets'] = event['targets'][:MAX_DST_IPS_PER_EVENT]
+
             # Send data to output interface
             trap.send(bytearray(json.dumps(event), "utf-8"))
         except pytrap.Terminated:

--- a/blacklistfilter/urlblacklist_aggregator.py
+++ b/blacklistfilter/urlblacklist_aggregator.py
@@ -83,10 +83,18 @@ def sendEvents():
     for key in eventList:
         event = eventList[key]
         try:
-            if len(event['targets']) > MAX_DST_IPS_PER_EVENT:
-                event['targets'] = event['targets'][:MAX_DST_IPS_PER_EVENT]
-            # Send data to output interface
-            trap.send(bytearray(json.dumps(event), "utf-8"))
+            # To avoid too long messages, split the event if there are more 1000 IPs
+            if len(event["targets"]) > MAX_DST_IPS_PER_EVENT:
+                targets = event["targets"]
+                while targets:
+                    event_copy = event.copy()
+                    event_copy["targets"] = targets[:MAX_DST_IPS_PER_EVENT]
+                    targets = targets[MAX_DST_IPS_PER_EVENT:]
+                    trap.send(bytearray(json.dumps(event_copy), "utf-8"))
+
+            else:
+                # Send data to output interface
+                trap.send(bytearray(json.dumps(event), "utf-8"))
         except pytrap.Terminated:
             print("Terminated TRAP.")
             break

--- a/blacklistfilter/urlblacklist_aggregator.py
+++ b/blacklistfilter/urlblacklist_aggregator.py
@@ -19,6 +19,9 @@ parser.add_option("-t", "--time", dest="time", type="float",
 
 lock = Lock()
 
+# Maximum number of dest. IPs in an event record (if there are more, they are trimmed)
+MAX_DST_IPS_PER_EVENT = 1000
+
 
 class RepeatedTimer(object):
     def __init__(self, interval, function):
@@ -80,6 +83,8 @@ def sendEvents():
     for key in eventList:
         event = eventList[key]
         try:
+            if len(event['targets']) > MAX_DST_IPS_PER_EVENT:
+                event['targets'] = event['targets'][:MAX_DST_IPS_PER_EVENT]
             # Send data to output interface
             trap.send(bytearray(json.dumps(event), "utf-8"))
         except pytrap.Terminated:


### PR DESCRIPTION
1) Aggregators now split long lists of target IPs and send it to reporters separately
2) Added mining blacklists
3) Fixed downloader to compare old and new blacklists correctly