### PR TITLE
blacklistfilter: Speed up aggregator, Add some blacklists

### DIFF
--- a/blacklistfilter/blacklist_aggregator.py
+++ b/blacklistfilter/blacklist_aggregator.py
@@ -34,11 +34,12 @@ stop = 0
 
 
 def signal_h(signal, f):
-    global stop
+    global stop, trap
     if stop:
         print('Caught another SIGINT, exiting immediately..')
         exit(1)
     print('Caught SIGINT, exiting gracefully..')
+    trap.terminate()
     stop = 1
 
 
@@ -398,7 +399,6 @@ if __name__ == '__main__':
     rt.stop()
     send_events()
     trap.sendFlush()
-    trap.terminate()
     trap.finalize()
 
 

--- a/blacklistfilter/blacklist_downloader/bl_downloader_config.xml
+++ b/blacklistfilter/blacklist_downloader/bl_downloader_config.xml
@@ -95,6 +95,55 @@
                 <element name="name">Cryptoioc Miners</element>
                 <element name="download_interval">10</element>
             </struct>
+
+            <struct>
+                <element name="id">9</element>
+                <element name="category">Malware</element>
+                <element name="method">web</element>
+                <element name="source">http://cinsscore.com/list/ci-badguys.txt</element>
+                <element name="name">CI Army - BadGuys</element>
+                <element name="download_interval">10</element>
+            </struct>
+
+            <struct>
+                <element name="id">10</element>
+                <element name="category">Malware</element>
+                <element name="method">web</element>
+                <element name="source">http://217.31.192.50/data/latest-proki.txt</element>
+                <element name="name">CZ.NIC Honeypot Cowrie</element>
+                <element name="download_interval">10</element>
+            </struct>
+
+            <struct>
+                <element name="id">11</element>
+                <element name="category">Malware</element>
+                <element name="method">web</element>
+                <element name="source">http://217.31.192.50/data/latest-dionaea.txt</element>
+                <element name="name">CZ.NIC Honeypot Dionaea</element>
+                <element name="download_interval">10</element>
+            </struct>
+
+            <struct>
+                <element name="id">12</element>
+                <element name="category">Malware</element>
+                <element name="method">web</element>
+                <element name="source">https://malc0de.com/bl/IP_Blacklist.txt</element>
+                <element name="name">Malc0de</element>
+                <element name="download_interval">10</element>
+            </struct>
+
+            <struct>
+                <element name="id">13</element>
+                <element name="category">Malware</element>
+                <element name="method">web</element>
+                <element name="source">http://www.urlvir.com/export-ip-addresses</element>
+                <element name="name">URLVir</element>
+                <element name="download_interval">10</element>
+            </struct>
+
+
+
+
         </array>
 
         <array type="URL/DNS">
@@ -174,6 +223,16 @@
                 <element name="source">https://zeustracker.abuse.ch/blocklist.php?download=compromised</element>
                 <element name="name">Zeus Tracker</element>
                 <element name="category">Intrusion.Botnet</element>
+                <element name="download_interval">10</element>
+                <element name="detectors">URL,DNS</element>
+            </struct>
+
+            <struct>
+                <element name="id">8</element>
+                <element name="method">web</element>
+                <element name="source">https://ransomwaretracker.abuse.ch/downloads/RW_DOMBL.txt</element>
+                <element name="name">Ransomware Tracker</element>
+                <element name="category">Malware.Ransomware</element>
                 <element name="download_interval">10</element>
                 <element name="detectors">URL,DNS</element>
             </struct>


### PR DESCRIPTION
1) Receivers of blacklist aggregator now only receive data and store them into a queue, where another threads then process the data. This way the receiver threads do the minimum amount of work.

2) Added some blacklists from PROKI