### PR TITLE
blacklistfilter: fixed build as a nemea/ submodule

### DIFF
--- a/blacklistfilter/dnsblacklistfilter.cpp
+++ b/blacklistfilter/dnsblacklistfilter.cpp
@@ -55,7 +55,8 @@
 #include <vector>
 #include <dnsdetect/patternstrings.h>
 #include <libtrap/trap.h>
-#include <nemea-common/nemea-common.h>
+/* include from nemea-common */
+#include <nemea-common.h>
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>

--- a/blacklistfilter/dnsblacklistfilter.h
+++ b/blacklistfilter/dnsblacklistfilter.h
@@ -56,7 +56,9 @@ extern "C" {
 #endif
 
 #include <unirec/unirec.h>
-#include <nemea-common/prefix_tree.h>
+
+/* include from nemea-common */
+#include <prefix_tree.h>
 
 /**
  * Constant returned if everything is ok.

--- a/blacklistfilter/ipblacklistfilter.cpp
+++ b/blacklistfilter/ipblacklistfilter.cpp
@@ -67,7 +67,8 @@
 #define DBG(x)
 #endif
 
-#include <nemea-common/nemea-common.h>
+/* include from nemea-common */
+#include <nemea-common.h>
 #include "ipblacklistfilter.h"
 #include "fields.h"
 #include "blacklist_watcher.h"

--- a/blacklistfilter/urlblacklistfilter.cpp
+++ b/blacklistfilter/urlblacklistfilter.cpp
@@ -55,7 +55,8 @@
 #include <urldetect/patternstrings.h>
 #include <libtrap/trap.h>
 #include <unirec/unirec.h>
-#include <nemea-common/nemea-common.h>
+/* include from nemea-common */
+#include <nemea-common.h>
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>

--- a/blacklistfilter/urlblacklistfilter.h
+++ b/blacklistfilter/urlblacklistfilter.h
@@ -56,7 +56,8 @@ extern "C" {
 #endif
 
 #include <unirec/unirec.h>
-#include <nemea-common/prefix_tree.h>
+/* include from nemea-common */
+#include <prefix_tree.h>
 
 
 /**


### PR DESCRIPTION
Configure (especially nemea-common M4 macro) sets correct path to
include header files of nemea-common, which is normally installed into
/usr/include/nemea-common/.
We should, therefore, include just the header file without
`nemea-common/` prefix.  Otherwise, it is not possible to compile
the repository as a submodule of nemea repository.