### PR TITLE
brute_force_detector: Fix DIV0 check in printFlowPercent()

### DIFF
--- a/brute_force_detector/brute_force_detector.cpp
+++ b/brute_force_detector/brute_force_detector.cpp
@@ -150,7 +150,7 @@ bool checkForTimeout(ur_time_t oldTime, ur_time_t timer, ur_time_t actualTime)
 
 void printFlowPercent(uint64_t b, uint64_t p)
 {
-    if (b && p && b * p) {
+    if (b) {
         ios::fmtflags f(cout.flags());
         cout << " ("
             << std::fixed << std::setprecision(2)


### PR DESCRIPTION
* The original condition (b && p && b * p) is equivalent to (b && p)
  as (b * p) can only be 0 if either b or p is. Then, only b is the
  denominator and although of low probability, p can actually be 0.
  We don't want to fail in that case so the final condition should
  be (b).