### PR TITLE
blacklist_downloader: BUGFIX regex cannot match IPv6

### DIFF
--- a/blacklistfilter/blacklist_downloader/bl_downloader.py.in
+++ b/blacklistfilter/blacklist_downloader/bl_downloader.py.in
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import sys
 import xml.etree.ElementTree as ET
 import requests
 import logging
@@ -518,7 +519,7 @@ class URLandDNSBlacklist(Blacklist):
 
         except OSError as e:
             logger.critical('Failed to create detector file. {}. Exiting downloader'.format(e))
-            exit(1)
+            sys.exit(1)
 
     def extract_entities_json(self, blacklist_file):
         """unused, no url blacklists use json"""

--- a/blacklistfilter/blacklist_downloader/bl_downloader.py.in
+++ b/blacklistfilter/blacklist_downloader/bl_downloader.py.in
@@ -355,12 +355,11 @@ class IPv6Blacklist(Blacklist):
 
         for line in blacklist_data.decode('utf-8').splitlines():
             try:
-                ipnet = ipaddress.ip_network(line)
-                if ipnet.version == 6:
-                    if ipnet.prefixlen == 128:
-                        extracted.append(ipnet.network_address.exploded)
-                    else:
-                        extracted.append(ipnet.exploded)
+                ipnet = ipaddress.IPv6Network(line)
+                if ipnet.prefixlen == 128:
+                    extracted.append(ipnet.network_address.exploded)
+                else:
+                    extracted.append(ipnet.exploded)
             except ValueError as e:
                 logger.warning('Could not parse IP address: {}\n{}'.format(line, e))
 
@@ -408,12 +407,11 @@ class IPv4Blacklist(Blacklist):
 
         for line in blacklist_data.decode('utf-8').splitlines():
             try:
-                ipnet = ipaddress.ip_network(line)
-                if ipnet.version == 4:
-                    if ipnet.prefixlen == 32:
-                        extracted.append(ipnet.network_address.exploded)
-                    else:
-                        extracted.append(ipnet.exploded)
+                ipnet = ipaddress.IPv4Network(line)
+                if ipnet.prefixlen == 32:
+                    extracted.append(ipnet.network_address.exploded)
+                else:
+                    extracted.append(ipnet.exploded)
             except ValueError as e:
                 logger.warning('Could not parse IP address: {}\n{}'.format(line, e))
 

--- a/blacklistfilter/blacklist_downloader/bl_downloader.py.in
+++ b/blacklistfilter/blacklist_downloader/bl_downloader.py.in
@@ -29,7 +29,7 @@ logger.addHandler(cs)
 ip4_regex = re.compile('\\b(?:(?:2(?:5[0-5]|[0-4][0-9])|[01]?[0-9][0-9]?)\.){3}(?:2(?:5[0-5]|[0-4][0-9])|[01]?[0-9][0-9]?)(?:(?:/(3[012]|[12]?[0-9]))?)\\b')
 
 # IPv6 regex -- matches only IPv6 (prefix not included)
-ip6_regex = re.compile('\\b^[a-fA-F0-9:]+(/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])\\b)?$')
+ip6_regex = re.compile('^[a-fA-F0-9:]+(/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?$')
 
 # Just a simple regex to eliminate commentaries
 url_regex = re.compile('^[^#/].*\..+')

--- a/blacklistfilter/blacklist_downloader/bl_downloader.py.in
+++ b/blacklistfilter/blacklist_downloader/bl_downloader.py.in
@@ -26,8 +26,14 @@ cs.setFormatter(formatter)
 logger = logging.getLogger(__name__)
 logger.addHandler(cs)
 
+# IPv4 regex -- matches IPv4 + optional prefix
+ip4_regex = re.compile(r'\b((?:(?:2(?:5[0-5]|[0-4][0-9])|[01]?[0-9][0-9]?)\.){3}(?:2(?:5[0-5]|[0-4][0-9])|[01]?[0-9][0-9]?))(?:(?:/(3[012]|[12]?[0-9]))?)\b')
+
+# IPv6 regex -- matches characters of IPv6 + optional prefix (IPv6 might not be valid, it is further processed by ipaddress module)
+ip6_regex = re.compile(r'([a-f0-9:]+)(/([1-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])\b)?', re.IGNORECASE)
+
 # Just a simple regex to eliminate commentaries
-url_regex = re.compile('^[^#/].*\..+')
+url_regex = re.compile(r'^[^#/].*\..+')
 
 # FQDN regex for DNS
 # taken from: https://github.com/guyhughes/fqdn/blob/develop/fqdn/__init__.py
@@ -345,24 +351,26 @@ class IPv6Blacklist(Blacklist):
 
     @staticmethod
     def extract_entities(blacklist_data):
-        """Extract IPv6 addresses from a (plaintext) blacklist file
+        """Extract IPv6 addresses from a (plaintext) blacklist file, using regex and ipaddress module
 
         Args:
-            blacklist_data: Downloaded blacklist file data
+            blacklist_data: Downloaded blacklist file data with multiple lines containing IP addresses with optional comments
 
         Returns: List of IPv6 addresses
         """
         extracted = []
 
         for line in blacklist_data.decode('utf-8').splitlines():
-            try:
-                ipnet = ipaddress.IPv6Network(line)
-                if ipnet.prefixlen == 128:
-                    extracted.append(ipnet.network_address.exploded)
-                else:
-                    extracted.append(ipnet.exploded)
-            except ValueError as e:
-                logger.warning('Could not parse IP address: {}\n{}'.format(line, e))
+            match = re.search(ip6_regex, line)
+            if match:
+                try:
+                    ipnet = ipaddress.IPv6Network(match.group(0))
+                    if ipnet.prefixlen == 128:
+                        extracted.append(ipnet.network_address.exploded)
+                    else:
+                        extracted.append(ipnet.exploded)
+                except ValueError as e:
+                    logger.warning('Could not parse IP address: {}\n{}'.format(line, e))
 
         return extracted
 
@@ -397,7 +405,7 @@ class IPv4Blacklist(Blacklist):
 
     @staticmethod
     def extract_entities(blacklist_data):
-        """Extract IPv4 addresses from a (plaintext) blacklist file
+        """Extract IPv4 addresses from a (plaintext) blacklist file, using regex
 
         Args:
             blacklist_data: Downloaded blacklist file data
@@ -407,14 +415,15 @@ class IPv4Blacklist(Blacklist):
         extracted = []
 
         for line in blacklist_data.decode('utf-8').splitlines():
-            try:
-                ipnet = ipaddress.IPv4Network(line)
-                if ipnet.prefixlen == 32:
-                    extracted.append(ipnet.network_address.exploded)
+            # regex already matches the prefix - if present
+            match = re.search(ip4_regex, line)
+            if match:
+                if not match.group(2) or match.group(2) == '32':  # ignore default /32 prefix
+                    extracted.append(match.group(1))
                 else:
-                    extracted.append(ipnet.exploded)
-            except ValueError as e:
-                logger.warning('Could not parse IP address: {}\n{}'.format(line, e))
+                    extracted.append(match.group(0)) # append IP with prefix
+            else:
+                logger.error('Could not parse IP address from line: %s' % line)
 
         return extracted
 

--- a/blacklistfilter/blacklist_downloader/bl_downloader.py.in
+++ b/blacklistfilter/blacklist_downloader/bl_downloader.py.in
@@ -113,7 +113,8 @@ class Blacklist:
 
         for blacklist, ports in self.entities.items():
             output += blacklist + ':'
-            ports.remove(PORT_UNKNOWN)
+            if PORT_UNKNOWN in ports:
+                ports.remove(PORT_UNKNOWN)
             output += ",".join([str(i) for i in sorted(ports)]) + '\n'
 
         return output

--- a/blacklistfilter/blacklist_downloader/bl_downloader.py.in
+++ b/blacklistfilter/blacklist_downloader/bl_downloader.py.in
@@ -25,12 +25,6 @@ cs.setFormatter(formatter)
 logger = logging.getLogger(__name__)
 logger.addHandler(cs)
 
-# IPv4 regex -- matches IPv4 + optional prefix
-ip4_regex = re.compile('\\b(?:(?:2(?:5[0-5]|[0-4][0-9])|[01]?[0-9][0-9]?)\.){3}(?:2(?:5[0-5]|[0-4][0-9])|[01]?[0-9][0-9]?)(?:(?:/(3[012]|[12]?[0-9]))?)\\b')
-
-# IPv6 regex -- matches only IPv6 (prefix not included)
-ip6_regex = re.compile('^[a-fA-F0-9:]+(/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?$')
-
 # Just a simple regex to eliminate commentaries
 url_regex = re.compile('^[^#/].*\..+')
 
@@ -119,10 +113,9 @@ class Blacklist:
 
         for blacklist, ports in self.entities.items():
             output += blacklist + ':'
-            for port in sorted(ports):
-                if port != -1:
-                    output += str(port) + ','
-            output = output[:-1] + '\n'  # remove last comma
+            ports.remove(PORT_UNKNOWN)
+            output += ",".join([str(i) for i in sorted(ports)]) + '\n'
+
         return output
 
     @staticmethod
@@ -350,7 +343,7 @@ class IPv6Blacklist(Blacklist):
 
     @staticmethod
     def extract_entities(blacklist_data):
-        """Extract IPv6 addresses from a (plaintext) blacklist file, using regex
+        """Extract IPv6 addresses from a (plaintext) blacklist file
 
         Args:
             blacklist_data: Downloaded blacklist file data
@@ -360,22 +353,15 @@ class IPv6Blacklist(Blacklist):
         extracted = []
 
         for line in blacklist_data.decode('utf-8').splitlines():
-            match = re.search(ip6_regex, line)
-            if match:
-                try:
-                    ip, prefix = match.group(0).split('/')
-                except ValueError:
-                    # no prefix found, assume /128
-                    ip = match.group(0)
-                    prefix = '128'
-
-                try:
-                    exploded_ip = ipaddress.IPv6Address(ip).exploded
-                    ip = exploded_ip + '/' + prefix
-                    extracted.append(ip)
-                except ipaddress.AddressValueError as e:
-                    # invalid IPv6 format
-                    logger.warning('Could not parse IPv6: {}\n{}'.format(line, e))
+            try:
+                ipnet = ipaddress.ip_network(line)
+                if ipnet.version == 6:
+                    if ipnet.prefixlen == 128:
+                        extracted.append(ipnet.network_address.exploded)
+                    else:
+                        extracted.append(ipnet.exploded)
+            except ValueError as e:
+                logger.warning('Could not parse IP address: {}\n{}'.format(line, e))
 
         return extracted
 
@@ -410,7 +396,7 @@ class IPv4Blacklist(Blacklist):
 
     @staticmethod
     def extract_entities(blacklist_data):
-        """Extract IPv4 addresses from a (plaintext) blacklist file, using regex
+        """Extract IPv4 addresses from a (plaintext) blacklist file
 
         Args:
             blacklist_data: Downloaded blacklist file data
@@ -420,10 +406,15 @@ class IPv4Blacklist(Blacklist):
         extracted = []
 
         for line in blacklist_data.decode('utf-8').splitlines():
-            # regex already matches the prefix - if present
-            match = re.search(ip4_regex, line)
-            if match and match.group(1) != '32':  # ignore default /32 prefix
-                extracted.append(match.group(0))
+            try:
+                ipnet = ipaddress.ip_network(line)
+                if ipnet.version == 4:
+                    if ipnet.prefixlen == 32:
+                        extracted.append(ipnet.network_address.exploded)
+                    else:
+                        extracted.append(ipnet.exploded)
+            except ValueError as e:
+                logger.warning('Could not parse IP address: {}\n{}'.format(line, e))
 
         return extracted
 

--- a/blacklistfilter/blacklist_downloader/bl_downloader.py.in
+++ b/blacklistfilter/blacklist_downloader/bl_downloader.py.in
@@ -29,7 +29,7 @@ logger.addHandler(cs)
 ip4_regex = re.compile('\\b(?:(?:2(?:5[0-5]|[0-4][0-9])|[01]?[0-9][0-9]?)\.){3}(?:2(?:5[0-5]|[0-4][0-9])|[01]?[0-9][0-9]?)(?:(?:/(3[012]|[12]?[0-9]))?)\\b')
 
 # IPv6 regex -- matches only IPv6 (prefix not included)
-ip6_regex = re.compile('\\b^[a-fA-F0-9:]+(/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?\\b')
+ip6_regex = re.compile('\\b^[a-fA-F0-9:]+(/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])\\b)?$')
 
 # Just a simple regex to eliminate commentaries
 url_regex = re.compile('^[^#/].*\..+')


### PR DESCRIPTION
IPv6 address without netmask (e.g., 'aaaa:ffff::') cannot be parsed;
meanwhile the same address with netmask works.
This patch changes regex - moves word border into optional mask because
valid IP can end with '::'.