### PR TITLE
Refactor

### DIFF
--- a/blacklistfilter/ipblacklistfilter.cpp
+++ b/blacklistfilter/ipblacklistfilter.cpp
@@ -489,7 +489,10 @@ uint64_t check_ports_get_bitfield(const ip_bl_entry_t &bl_entry, uint16_t port)
 
    for (const auto &blacklist: bl_entry.bl_ports) {
       if (blacklist.second.find(port) == blacklist.second.end()) {
-         inverse_matched_bitfield |= (uint64_t)(1u << (uint32_t)(blacklist.first - 1));
+         const uint64_t one = 1;
+         const int key = blacklist.first;
+         const uint64_t set_bit = key > 0 && key <= 63 ? (one << (key - 1)) : 0;
+         inverse_matched_bitfield |= set_bit;
       }
    }
 

--- a/brute_force_detector/whitelist.cpp
+++ b/brute_force_detector/whitelist.cpp
@@ -228,6 +228,18 @@ bool Whitelist::trieSearch(IPTrie *ipTrie, uint8_t *ip, uint8_t ipType, uint16_t
       }
    }
 
+   // last chance to return true
+   if (currentNode->set) {
+      if (currentNode->allPorts) {
+         return true;
+      }
+      if (currentNode->whitelistedPorts != NULL) {
+         if ((currentNode->whitelistedPorts->findPort(port)) == true) {
+            return true;
+         }
+      }
+   }
+
    return false;
 }
 

--- a/brute_force_detector/whitelist.cpp
+++ b/brute_force_detector/whitelist.cpp
@@ -198,7 +198,7 @@ bool Whitelist::isWhitelisted(const ip_addr_t *srcIp, const ip_addr_t *dstIp, ui
 bool Whitelist::trieSearch(IPTrie *ipTrie, uint8_t *ip, uint8_t ipType, uint16_t port)
 {
    IPTrie *currentNode = ipTrie;
-   int iRange = (ipType == 4) ? 32 : 128;
+   int iRange = (ipType == 4) ? 4 : 16; // 32bits : 128bits
 
    for (int i = 0; i < iRange; i++) {
       for (int u = 7; u >= 0; u--) {

--- a/hoststatsnemea/src/processdata.cpp
+++ b/hoststatsnemea/src/processdata.cpp
@@ -160,7 +160,7 @@ void *data_reader_trap(void *args)
       if (data_size < ur_rec_fixlen_size(tmpl_in)) {
          if (data_size > 1) {
             log(LOG_ERR, "Error: data with wrong size received (expected size: "
-               "%lu, received size: %i.)\nHint: if you are using this module "
+               "%u, received size: %i.)\nHint: if you are using this module "
                "without flowdirection module change value 'port-flowdir' in "
                "the configuration file (hoststats.conf by default)",
                ur_rec_fixlen_size(tmpl_in), data_size);
@@ -280,7 +280,7 @@ void offline_analyzer()
       if (data_size < ur_rec_fixlen_size(tmpl_in)) {
          if (data_size > 1) {
             log(LOG_ERR, "Error: data with wrong size received (expected size: "
-               "%lu, received size: %i)", ur_rec_fixlen_size(tmpl_in), data_size);
+               "%u, received size: %i)", ur_rec_fixlen_size(tmpl_in), data_size);
             return;
          }
          end_of_steam = true;

--- a/hoststatsnemea/src/profile.cpp
+++ b/hoststatsnemea/src/profile.cpp
@@ -130,7 +130,7 @@ HostProfile::HostProfile()
    bp.projected_element_count = 2 * table_size;
    bp.false_positive_probability = 0.01;
    bp.compute_optimal_parameters();
-   log(LOG_DEBUG, "process_data: Creating Bloom Filter, table size: %lu, hashes: %lu",
+   log(LOG_DEBUG, "process_data: Creating Bloom Filter, table size: %lu, hashes: %u",
       bp.optimal_parameters.table_size, bp.optimal_parameters.number_of_hashes);
    bf_com_active = new bloom_filter(bp);
    bf_com_learn = new bloom_filter(bp);

--- a/hoststatsnemea/src/profile.cpp
+++ b/hoststatsnemea/src/profile.cpp
@@ -130,7 +130,7 @@ HostProfile::HostProfile()
    bp.projected_element_count = 2 * table_size;
    bp.false_positive_probability = 0.01;
    bp.compute_optimal_parameters();
-   log(LOG_DEBUG, "process_data: Creating Bloom Filter, table size: %d, hashes: %d",
+   log(LOG_DEBUG, "process_data: Creating Bloom Filter, table size: %lu, hashes: %lu",
       bp.optimal_parameters.table_size, bp.optimal_parameters.number_of_hashes);
    bf_com_active = new bloom_filter(bp);
    bf_com_learn = new bloom_filter(bp);


### PR DESCRIPTION
## Report

## brute_force_detector/whitelist.cpp

There was code:
``` C++
if (((ip[i] >> u) & 1) > 0) {
```
Where the variable **i** could take values that would cause incorrect out-of-bound access. But surprisingly, tests (whitelist_unit_test) did not detect this error. I fixed the initialization of the **iRange** variable and added another block of code to pass the tests.

## Other issues

- Invalid type in argument to printf format specifier
- Unintentional integer overflow
