### PR TITLE
blacklistfilter: List of blacklists updated

### DIFF
--- a/blacklistfilter/blacklist_downloader/bl_downloader_config.xml
+++ b/blacklistfilter/blacklist_downloader/bl_downloader_config.xml
@@ -230,7 +230,6 @@
             -->
             
             <!-- URLhaus (online only), info: https://urlhaus.abuse.ch/ -->
-            <!-- Also provides ports, use https://sslbl.abuse.ch/blacklist/sslipblacklist.csv when support for ports is implemented -->
             <struct>
                 <element name="id">8</element>
                 <element name="category">Malware</element>


### PR DESCRIPTION
- Removed:
  - Andoniaf Miners (not updated since Apr 2018)
  - CI Army - BadGuys (these are probably active attackers/scanners, not C&C and other infrastructure, so we don't want it here)
  - CZ.NIC Honeypot Cowrie/Dionaea (doesn't work now and also listed active attackers)
  - Malc0de (not updated since Dec 2019)
  - Smashed Miners (doesn't work)
  - DisconnectMe (doesn't work anymore)
  - SquidBlacklist (doesn't work anymore)

- Added:
  - Abuse.ch ThreatFox IPs/domains/URLs
  - Abuse.ch SSL blacklist
  - KriskIntel malware IPs/domains
  - KriskIntel phishing domains
  - Blackbook (domains)
  - VXVault Malware download URLs

Note: ThreatFox lists doesn't work yet, support for zipped files and for "IP:port" pairs must be implemented first.