### PR TITLE
bl_downloader: fixed writing of output files, described format in README

### DIFF
--- a/blacklistfilter/blacklist_downloader/README.md
+++ b/blacklistfilter/blacklist_downloader/README.md
@@ -116,13 +116,31 @@ Demonstrated also by UML diagram below:
 
 ![URL preprocessing](../doc/downloader_final.png)
 
-## About detector files
+## Output file format
 
-Detector files are special files created by blacklist downloader for the detectors (ip/url/dns). 
-Every row contains an entity, separator and blacklist index. All the entities are sorted (especially useful for ip blacklistfilter, which uses binary search). When there is a change in any blacklist of a given type, new detector file is created (rewrites the old one). The detector listens for the file change (inotify's IN_CLOSE_WRITE flag) and reloads the file when
+_Detector files_ are special files created by blacklist downloader for the detectors (ip/url/dns). 
+Every row contains an entity, separator and blacklist index, e.g. `1.10.16.1,8`.
+The separator is `,` for IP blacklists, `\` for URL and DNS blacklists.
+
+The blacklist index is a bitmap, a bit set on `i`th position (counted from 1) means presence o blacklist with id `i-1`.
+For example, value 9 means the entity is present on the blacklists with ID 1 and 4.
+
+IP blacklists also support specification of ports.
+For each blacklist the IP is present on, a set of port numbers can also be specified.
+This is appended after the blacklist index as a list of pairs (blacklist-id, list-of-ports).
+The pairs are separated by `;`, ports within the `list-of-ports` are separated by `,`.
+
+The complete format is:
+```
+IP blacklists:
+entity_id ',' blacklist_index_bitfield [ ';' bl_id ':' port [ ',' port ... ] ] [';' bl_id ':' ... ]
+
+DNS/URL blacklists:
+entity_id '\' blacklist_index_bitfield
+```
+
+All the entities are sorted (especially useful for ip blacklistfilter, which uses binary search). When there is a change in any blacklist of a given type, new detector file is created (rewrites the old one). The detector listens for the file change (inotify's IN_CLOSE_WRITE flag) and reloads the file when
 there is a change. The detector doesn't have to process the data, it just loads them and detects. All the preprocessing (sorting, case-insensitivying, ..) is done by the downloader.
-
-The blacklist index is a bitmap, so a value 9 means the entity is present on the blacklists with ID 1 and 4.
 
 
 ### Examples
@@ -133,6 +151,8 @@ The blacklist index is a bitmap, so a value 9 means the entity is present on the
 1.22.124.243,256
 1.22.180.84,256
 1.22.241.193,256
+1.30.40.5,9;1:80,8080,443;4:80
+1.31.1.100,7;2:22
 ```
 
 */tmp/blacklistfilter/ip6.blist*

--- a/blacklistfilter/blacklist_downloader/bl_downloader.py.in
+++ b/blacklistfilter/blacklist_downloader/bl_downloader.py.in
@@ -155,16 +155,14 @@ class Blacklist:
         Blacklist entities expected to be sorted
 
         Returns:
-            String with entities from this blacklist, in the version control file format
+            String with entities from this blacklist, in the version control file format ("bl_id:port_list")
 
         """
         output = ''
 
         for blacklist, ports in self.entities.items():
             output += blacklist + ':'
-            if PORT_UNKNOWN in ports:
-                ports.remove(PORT_UNKNOWN)
-            output += ",".join([str(i) for i in sorted(ports)]) + '\n'
+            output += ",".join([str(p) for p in sorted(ports) if p != PORT_UNKNOWN]) + '\n'
 
         return output
 
@@ -172,7 +170,8 @@ class Blacklist:
     def stringify_blacklists_detector_file(entities_dict, bitfield_separator):
         """Output string with entries in the detector file format (.blist)
 
-        entities_dict (OrderedDict) is expected to be already sorted
+        entities_dict: dict(ip -> dict(blacklist_id -> set_of_ports)
+        entities_dict is expected to be already sorted (OrderedDict)
         set of ports is NOT expected to be sorted
 
         Returns:
@@ -182,38 +181,26 @@ class Blacklist:
         separator_blacklists = ';'
 
         for ip in entities_dict:
-            # IP
-            output += ip + bitfield_separator
-
-            # blacklists bitfield
+            # blacklists bitfield (1 on i'th position when IP is on blacklist with id 'i')
             bitfield = 0
 
-            # blacklist: ports
-            all_blacklists = ''
+            # list of ports per blacklist (";bl_id:comma_separated_list_of_ports;...")
+            ports_per_bl = ''
 
             for blacklist in entities_dict[ip]:
-                ignore_list = False
+                # Construct bitfield
                 bitfield |= 2 ** (blacklist - 1)
-                single_blacklist = str(blacklist) + ':'
-
+                # Construct list of ports per blacklist
+                # ("bl_id:comma_separated_list_of_port")
                 ports = sorted(entities_dict[ip][blacklist])
+                if PORT_UNKNOWN in ports:
+                    continue
+                ports_per_bl += separator_blacklists
+                ports_per_bl += str(blacklist) + ':'
+                ports_per_bl += ','.join(map(str, ports))
 
-                for port in ports:
-                    if port == PORT_UNKNOWN:
-                        ignore_list = True
-                    single_blacklist += str(port) + ','
-
-                # replace last port separator by blacklist separator
-                single_blacklist = single_blacklist[:-1] + separator_blacklists
-
-                if not ignore_list:
-                    all_blacklists += single_blacklist
-
-            output += str(bitfield)
-            if len(all_blacklists) > 0:
-                output += separator_blacklists + all_blacklists[:-1]
-
-            output += '\n'
+            # Output line
+            output += ip + bitfield_separator + str(bitfield) + ports_per_bl + '\n'
 
         return output
 
@@ -264,7 +251,7 @@ class Blacklist:
                 if ports == {PORT_UNKNOWN} and len(all_entities_dict[entity][blacklist_id]) != 0:
                     pass  # do not add -1 if there are other ports present
                 else:
-                    all_entities_dict[entity][blacklist_id].append(ports)
+                    all_entities_dict[entity][blacklist_id].add(ports)
             except KeyError:
                 all_entities_dict[entity][blacklist_id] = ports
 


### PR DESCRIPTION
Generation of output files rewritten and fixed to not contain "ports" part if there is no port information.

NOTICE: The ports extension of the file format wasn't documented anywhere, so I reconstructed its probable definition from the parser code in ipblacklistfilter.cpp. It seems the files generated by bl_downloader can now be successfully read by ipblacklistfilter, but it's not thoroughly tested.